### PR TITLE
🗓️ fix(admin): ввод месяца и года для выставок через <input type="month">

### DIFF
--- a/art_gallery/show/admin.py
+++ b/art_gallery/show/admin.py
@@ -1,10 +1,13 @@
 from django.contrib import admin
 from adminsortable2.admin import SortableAdminMixin
+
+from .admin_forms import ExhibitionAdminForm
 from .models import Exhibition, VideoItem
 
 
 @admin.register(Exhibition)
 class ExhibitionAdmin(SortableAdminMixin, admin.ModelAdmin):
+    form = ExhibitionAdminForm
     list_display = ('date', 'title', 'venue', 'order')
     list_editable = ('order',)
 

--- a/art_gallery/show/admin_forms.py
+++ b/art_gallery/show/admin_forms.py
@@ -1,0 +1,14 @@
+from django import forms
+from .models import Exhibition
+
+
+class ExhibitionAdminForm(forms.ModelForm):
+    class Meta:
+        model = Exhibition
+        fields = '__all__'
+        widgets = {
+            'date': forms.DateInput(attrs={
+                'type': 'month',
+                'class': 'vDateField'
+            })
+        }


### PR DESCRIPTION
### Что сделано:

- Подключена кастомная форма `ExhibitionAdminForm` в админке
- Поле `date` заменено на `input type="month"` для выбора только месяца и года
- Администратору теперь проще указывать дату выставки (например, "Март 2025")
- Обновлены файлы:
  - `admin_forms.py` — добавлен виджет
  - `admin.py` — подключена форма в `ExhibitionAdmin`
  - `models.py` — сортировка по `order` сохранена

### Зачем:

- Упростить ввод даты
- Избежать обязательного указания числа
- Поддержать UX-ориентированную админку